### PR TITLE
refactor(variables.tf): [DVPS-896] pmlo-data-lake

### DIFF
--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -102,5 +102,5 @@ variable "task_instance_max_count" {
 }
 
 locals {
-  tags = merge(map("vendor", "segment"), var.tags)
+  tags = merge(tomap("vendor", "segment"), var.tags)
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -32,5 +32,5 @@ variable "tags" {
 }
 
 locals {
-  tags = merge(map("vendor", "segment"), var.tags)
+  tags = merge(tomap("vendor", "segment"), var.tags)
 }


### PR DESCRIPTION
This PR is to fix function error.

`Error: Error in function call

on .terraform/modules/emr/modules/emr/variables.tf line 105, in locals:
105: tags = merge(map("vendor", "segment"), var.tags)
Call to function "map" failed: the "map" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal map.`
