### PR TITLE
fix(emr): [DVPS-1005] cluster-instance-type

### DIFF
--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -62,19 +62,19 @@ variable "iam_emr_instance_profile" {
 variable "master_instance_type" {
   description = "EC2 Instance Type for Master"
   type        = string
-  default     = "c5.xlarge"
+  default     = "m5.xlarge" #2vCPUS,16gRAM
 }
 
 variable "core_instance_type" {
   description = "EC2 Instance Type for Core Nodes"
   type        = string
-  default     = "c5.xlarge"
+  default     = "m5.xlarge" #2vCPUS,16gRAM
 }
 
 variable "task_instance_type" {
   description = "EC2 Instance Type for Task Nodes"
   type        = string
-  default     = "c5.xlarge"
+  default     = "m5.xlarge" #2vCPUS,16gRAM
 }
 
 variable "core_instance_count" {

--- a/modules/emr/variables.tf
+++ b/modules/emr/variables.tf
@@ -62,19 +62,19 @@ variable "iam_emr_instance_profile" {
 variable "master_instance_type" {
   description = "EC2 Instance Type for Master"
   type        = string
-  default     = "m5.xlarge" #2vCPUS,16gRAM
+  default     = "c5.2xlarge" #8vCPUS,16gRAM
 }
 
 variable "core_instance_type" {
   description = "EC2 Instance Type for Core Nodes"
   type        = string
-  default     = "m5.xlarge" #2vCPUS,16gRAM
+  default     = "c5.2xlarge" #8vCPUS,16gRAM
 }
 
 variable "task_instance_type" {
   description = "EC2 Instance Type for Task Nodes"
   type        = string
-  default     = "m5.xlarge" #2vCPUS,16gRAM
+  default     = "c5.2xlarge" #8vCPUS,16gRAM
 }
 
 variable "core_instance_count" {


### PR DESCRIPTION
This PR change instance type to "m5.xlarge" #2vCPUS,16gRAM which recommended by documentation.

https://segment.com/docs/connections/storage/data-lakes/data-lakes-manual-setup/

JIRA: https://pomelofashion.atlassian.net/browse/DVPS-1005