### PR TITLE
refactor(ebs): [DVPS-1102] extend-ebs-volume-emr-cluster

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -35,7 +35,7 @@ resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {
     name           = "core_group"
 
     ebs_config {
-      size                 = "64"
+      size                 = "128"
       type                 = "gp2"
       volumes_per_instance = 1
     }


### PR DESCRIPTION
This PR to fix storage full on EMR cluster node and become failure.

![image](https://user-images.githubusercontent.com/98529991/177256491-7e4c9b10-83ba-4c32-bc5e-ab67828091b0.png)
