### PR TITLE
refactor(log): [DVPS-1102] clean-up-log-file-after-3-days

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -112,7 +112,12 @@ EOF
       "Classification": "yarn-site",
       "Properties": {
         "yarn.log-aggregation.retain-seconds": "259200"
-      }
+    },
+	{
+      "Classification": "yarn-site",
+      "Properties": {
+        "yarn.nodemanager.log-aggregation.compression-type": "gz"
+    }
     }
   ]
 EOF

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -106,7 +106,8 @@ EOF
     {
       "Classification": "spark-hive-site",
       "Properties": {
-        "hive.metastore.client.factory.class":"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"      }
+        "hive.metastore.client.factory.class":"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+	  }
     },
 	{
       "Classification": "yarn-site",

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -107,6 +107,12 @@ EOF
       "Classification": "spark-hive-site",
       "Properties": {
         "hive.metastore.client.factory.class":"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"      }
+    },
+	{
+      "Classification": "yarn-site",
+      "Properties": {
+        "yarn.log-aggregation.retain-seconds": "259200"
+      }
     }
   ]
 EOF


### PR DESCRIPTION
This PR will clean up log file in core node after 3 days at path /emr/instance-controller/log.

`{
      "Classification": "yarn-site",
      "Properties": {
        "yarn.log-aggregation.retain-seconds": "259200"
      }
    }
 `