### PR TITLE
fix(yarn): [DVPS-1102] too-many-yarn-error

### DIFF
--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -97,25 +97,25 @@ EOF
 
   configurations_json = <<EOF
   [
-   {
-      "Classification": "hive-site",
-      "Properties": {
-         "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
-      }
-   },
-   {
-      "Classification": "spark-hive-site",
-      "Properties": {
-         "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
-      }
-   },
-   {
-      "Classification": "yarn-site",
-      "Properties": {
-         "yarn.log-aggregation.retain-seconds": "259200",
-		 "yarn.nodemanager.log-aggregation.compression-type": "gz"
-      }
-   }
+  {
+    "Classification": "hive-site",
+    "Properties": {
+      "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+    }
+  },
+  {
+    "Classification": "spark-hive-site",
+    "Properties": {
+      "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+    }
+  },
+  {
+    "Classification": "yarn-site",
+    "Properties": {
+      "yarn.log-aggregation.retain-seconds": "259200",
+      "yarn.nodemanager.log-aggregation.compression-type": "gz"
+    }
+  }
 ]
 EOF
 

--- a/modules/emr/main.tf
+++ b/modules/emr/main.tf
@@ -112,13 +112,8 @@ EOF
    {
       "Classification": "yarn-site",
       "Properties": {
-         "yarn.log-aggregation.retain-seconds": "259200"
-      }
-   },
-   {
-      "Classification": "yarn-site",
-      "Properties": {
-         "yarn.nodemanager.log-aggregation.compression-type": "gz"
+         "yarn.log-aggregation.retain-seconds": "259200",
+		 "yarn.nodemanager.log-aggregation.compression-type": "gz"
       }
    }
 ]


### PR DESCRIPTION
This PR to fix too many yarn error in configuration.

`Terraform v0.14.2
Initializing plugins and modules...
module.emr.aws_emr_cluster.segment_data_lake_emr_cluster: Creating...

Error: error running EMR Job Flow: ValidationException: Classification 'yarn-site' was specified multiple times.
	status code: 400, request id: f245874a-02f9-4b3f-b0cf-5468507b0ffe

  on .terraform/modules/emr/modules/emr/main.tf line 3, in resource "aws_emr_cluster" "segment_data_lake_emr_cluster":
   3: resource "aws_emr_cluster" "segment_data_lake_emr_cluster" {


Operation failed: failed running terraform apply (exit 1)`